### PR TITLE
Fixed bug for when $post_id is 0

### DIFF
--- a/php/class-controller-assets.php
+++ b/php/class-controller-assets.php
@@ -40,7 +40,7 @@ class Controller_Assets {
 		wp_enqueue_style( 'link-picker-for-cmb2', $plugin_css_url );
 
 		/* Media */
-		if ( isset( $post_id ) ) {
+		if ( isset( $post_id ) && $post_id <> 0 ) {
 			wp_enqueue_media( array( 'post' => $post_id ) );
 		}
 


### PR DESCRIPTION
When loading other pages in the admin, I was getting a PHP notice because $post_id was 0.  This should fix that problem.